### PR TITLE
MINOR: avoiding partial json decoding to stdobject

### DIFF
--- a/src/PCSG/Makerlog/Api/Discussions.php
+++ b/src/PCSG/Makerlog/Api/Discussions.php
@@ -41,7 +41,7 @@ class Discussions
     public function getList()
     {
         $Request       = $this->Makerlog->getRequest()->get('/discussions');
-        $notifications = json_decode($Request->getBody());
+        $notifications = json_decode($Request->getBody(), true);
 
         return $notifications;
     }
@@ -55,7 +55,7 @@ class Discussions
     public function getRecent()
     {
         $Request       = $this->Makerlog->getRequest()->get('/discussions/recent_discussions');
-        $notifications = json_decode($Request->getBody());
+        $notifications = json_decode($Request->getBody(), true);
 
         return $notifications;
     }

--- a/src/PCSG/Makerlog/Api/Notifications.php
+++ b/src/PCSG/Makerlog/Api/Notifications.php
@@ -44,7 +44,7 @@ class Notifications
     {
         $notificationId = (int)$notificationId;
         $Request        = $this->Makerlog->getRequest()->get('/notifications/' . $notificationId);
-        $projects       = json_decode($Request->getBody());
+        $projects       = json_decode($Request->getBody(), true);
 
         return $projects;
     }
@@ -58,7 +58,7 @@ class Notifications
     public function getList()
     {
         $Request       = $this->Makerlog->getRequest()->get('/notifications');
-        $notifications = json_decode($Request->getBody());
+        $notifications = json_decode($Request->getBody(), true);
 
         return $notifications;
     }
@@ -73,7 +73,7 @@ class Notifications
     public function getUnreadCount()
     {
         $Request  = $this->Makerlog->getRequest()->get('/notifications/unread_count');
-        $projects = json_decode($Request->getBody());
+        $projects = json_decode($Request->getBody(), true);
 
         return (int)$projects->unread_count;
     }
@@ -92,7 +92,7 @@ class Notifications
         $notificationId = (int)$notificationId;
 
         $Request  = $this->Makerlog->getRequest()->post('/notifications/' . $notificationId . '/mark_read');
-        $projects = json_decode($Request->getBody());
+        $projects = json_decode($Request->getBody(), true);
 
         return $projects;
     }
@@ -108,7 +108,7 @@ class Notifications
     public function markAllRead()
     {
         $Request  = $this->Makerlog->getRequest()->post('/notifications/mark_all_read');
-        $projects = json_decode($Request->getBody());
+        $projects = json_decode($Request->getBody(), true);
 
         return $projects;
     }

--- a/src/PCSG/Makerlog/Api/Products.php
+++ b/src/PCSG/Makerlog/Api/Products.php
@@ -42,7 +42,7 @@ class Products
     public function getList()
     {
         $Request  = $this->Makerlog->getRequest()->get('/products');
-        $projects = json_decode($Request->getBody());
+        $projects = json_decode($Request->getBody(), true);
 
         return $projects;
     }
@@ -57,7 +57,7 @@ class Products
     public function get($slug)
     {
         $Request  = $this->Makerlog->getRequest()->get('/products/'.$slug);
-        $projects = json_decode($Request->getBody());
+        $projects = json_decode($Request->getBody(), true);
 
         return $projects;
     }
@@ -71,7 +71,7 @@ class Products
     public function getRecentlyLaunched()
     {
         $Request  = $this->Makerlog->getRequest()->get('/products/recently_launched');
-        $projects = json_decode($Request->getBody());
+        $projects = json_decode($Request->getBody(), true);
 
         return $projects;
     }

--- a/src/PCSG/Makerlog/Api/Projects.php
+++ b/src/PCSG/Makerlog/Api/Projects.php
@@ -42,7 +42,7 @@ class Projects
     public function getList()
     {
         $Request  = $this->Makerlog->getRequest()->get('/projects');
-        $projects = json_decode($Request->getBody());
+        $projects = json_decode($Request->getBody(), true);
 
         return $projects;
     }

--- a/src/PCSG/Makerlog/Api/Stats.php
+++ b/src/PCSG/Makerlog/Api/Stats.php
@@ -40,7 +40,7 @@ class Stats
     public function getStats()
     {
         $Request = $this->Makerlog->getRequest()->get('/stats/world');
-        $world   = json_decode($Request->getBody());
+        $world   = json_decode($Request->getBody(), true);
 
         return $world;
     }
@@ -54,7 +54,7 @@ class Stats
     public function getMe()
     {
         $Request = $this->Makerlog->getRequest()->get('/stats/me');
-        $world   = json_decode($Request->getBody());
+        $world   = json_decode($Request->getBody(), true);
 
         return $world;
     }

--- a/src/PCSG/Makerlog/Api/Tasks.php
+++ b/src/PCSG/Makerlog/Api/Tasks.php
@@ -44,7 +44,7 @@ class Tasks
     {
         $taskId  = (int)$taskId;
         $Request = $this->Makerlog->getRequest()->get('/tasks/' . $taskId);
-        $Task    = json_decode($Request->getBody());
+        $Task    = json_decode($Request->getBody(), true);
 
         if (!$Task) {
             throw new Exception('Task not found', 404);
@@ -60,7 +60,7 @@ class Tasks
     public function getList()
     {
         $Request  = $this->Makerlog->getRequest()->get('/tasks');
-        $projects = json_decode($Request->getBody());
+        $projects = json_decode($Request->getBody(), true);
 
         return $projects;
     }

--- a/src/PCSG/Makerlog/Api/Users.php
+++ b/src/PCSG/Makerlog/Api/Users.php
@@ -44,7 +44,7 @@ class Users
     {
         $userId  = (int)$userId;
         $Request = $this->Makerlog->getRequest()->get('/users/'.$userId);
-        $User    = json_decode($Request->getBody());
+        $User    = json_decode($Request->getBody(), true);
 
         if (!$User) {
             throw new Exception('User not found', 404);
@@ -64,7 +64,7 @@ class Users
     public function getByUsername($user)
     {
         $Request = $this->Makerlog->getRequest()->get('/users/'.$user);
-        $User    = json_decode($Request->getBody());
+        $User    = json_decode($Request->getBody(), true);
 
         if (!$User) {
             throw new Exception('User not found', 404);
@@ -82,7 +82,7 @@ class Users
     public function getMe()
     {
         $Request = $this->Makerlog->getRequest()->get('/me/');
-        $User    = json_decode($Request->getBody());
+        $User    = json_decode($Request->getBody(), true);
 
         return $User;
     }
@@ -96,7 +96,7 @@ class Users
     public function getMeAsObject()
     {
         $Request = $this->Makerlog->getRequest()->get('/me/');
-        $User    = json_decode($Request->getBody());
+        $User    = json_decode($Request->getBody(), true);
 
         return $this->getUserObject($User->username);
     }
@@ -122,7 +122,7 @@ class Users
     public function getList()
     {
         $Request  = $this->Makerlog->getRequest()->get('/users');
-        $users    = json_decode($Request->getBody());
+        $users    = json_decode($Request->getBody(), true);
         $maxUsers = $users->count;
 
         $batch  = 100;
@@ -137,7 +137,7 @@ class Users
                 ]
             ]);
 
-            $users  = json_decode($Request->getBody());
+            $users  = json_decode($Request->getBody(), true);
             $offset = $offset + $batch;
 
             // get twitter users from makerlog users
@@ -158,7 +158,7 @@ class Users
     public function count()
     {
         $Request = $this->Makerlog->getRequest()->get('/users');
-        $users   = json_decode($Request->getBody());
+        $users   = json_decode($Request->getBody(), true);
 
         return (int)$users->count;
     }

--- a/src/PCSG/Makerlog/Api/Users/User.php
+++ b/src/PCSG/Makerlog/Api/Users/User.php
@@ -449,6 +449,6 @@ class User
         $apiEndpoint = trim($apiEndpoint, '/').'/';
         $Request     = $this->Makerlog->getRequest()->get('/users/'.$this->username.'/'.$apiEndpoint);
 
-        return json_decode($Request->getBody());
+        return json_decode($Request->getBody(), true);
     }
 }

--- a/tests/prepare-tokens.php
+++ b/tests/prepare-tokens.php
@@ -38,7 +38,7 @@ function getTokens($user)
     ); // phantom bug - workaround
 
     $tokens = trim($tokens);
-    $tokens = json_decode($tokens);
+    $tokens = json_decode($tokens, true);
 
     return $tokens;
 }


### PR DESCRIPTION
Hello @dehenne 

I noticed that I'm getting stdobjects back. Comes from partial decoding of the json. I've fixed this in this PR. Let me know if you think its something you would merge!

-- Peter